### PR TITLE
Updating Package NaughtyAttributes from 2.0.6 to 2.0.7

### DIFF
--- a/SpaceUber/Packages/packages-lock.json
+++ b/SpaceUber/Packages/packages-lock.json
@@ -5,7 +5,7 @@
       "depth": 0,
       "source": "git",
       "dependencies": {},
-      "hash": "ed0edab05e0503622f0b6c6b41061d5fb64e3ece"
+      "hash": "c5140c7dc38427f93a63d8bd6604f90134943fe7"
     },
     "com.joaoborks.customscripttemplate": {
       "version": "https://github.com/JoaoBorks/unity-customscripttemplate.git",


### PR DESCRIPTION
Updating the NaughtAttributes pacakge from 2.0.6 to 2.0.7 because of new release in attempt to fix automatted builds.