### PR TITLE
Brig's Resource set to Credits (previously blank)

### DIFF
--- a/SpaceUber/Assets/Prefabs/RoomPrefabs/Brig.prefab
+++ b/SpaceUber/Assets/Prefabs/RoomPrefabs/Brig.prefab
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: bfec50bf890af17479ff38a5eee6322e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  resourceType: Payout
+  resourceType: Credits
   resourceIcon: {fileID: 21300000, guid: 2bbae6bacf5f9da4697f3b6af192e12a, type: 3}
   amount: 250
   activeAmount: 0


### PR DESCRIPTION
The Brig's output was supposed to affect the payout, but actaully wasn't due to it's resource not being set to Credits, but instead was blank.