### PR TITLE
Steven - Fixed Restarting Job/Run

### DIFF
--- a/SpaceUber/Assets/Scripts/GameManager.cs
+++ b/SpaceUber/Assets/Scripts/GameManager.cs
@@ -172,10 +172,16 @@ public class GameManager : MonoBehaviour
                 additiveSceneManager.UnloadScene("Event_General");
                 additiveSceneManager.UnloadScene("Event_CharacterFocused");
                 additiveSceneManager.UnloadScene("Event_Prompt");
+                additiveSceneManager.UnloadScene("Interface_EventTimer");
                 
                 additiveSceneManager.LoadSceneSeperate("PromptScreen_Mutiny");
                 break;
             case InGameStates.Death: // Loads the PromptScreen_Death when the player reaches a death.
+                additiveSceneManager.UnloadScene("Event_General");
+                additiveSceneManager.UnloadScene("Event_CharacterFocused");
+                additiveSceneManager.UnloadScene("Event_Prompt");
+                additiveSceneManager.UnloadScene("Interface_EventTimer");
+                
                 additiveSceneManager.LoadSceneSeperate("PromptScreen_Death");
                 break;
             default: // Output Warning when the passed in game state doesn't have a transition setup.


### PR DESCRIPTION
Event Timer is unloaded for Mutiny and Death. If the player restarts the Event state will reload the timer. Fixes: #239 