### PR TITLE
Added check for it the player is in a character event.

### DIFF
--- a/SpaceUber/Assets/Scripts/Event System/EventSystem.cs
+++ b/SpaceUber/Assets/Scripts/Event System/EventSystem.cs
@@ -215,8 +215,8 @@ public class EventSystem : MonoBehaviour
             tick.StopTickUpdate();
             FindObjectOfType<CrewManagement>().TurnOffPanel();
 
-			//wait until there is no longer an overclock microgame happening
-			yield return new WaitUntil(() => !OverclockController.instance.overclocking);
+			//wait until done with minigame and/or character event
+			yield return new WaitUntil(() => !OverclockController.instance.overclocking && !chatting);
 
             //If event button was not clicked ahead of time
             if (nextEventLockedIn && SceneManager.GetSceneByName("Event_Prompt").isLoaded)


### PR DESCRIPTION
Fixed softlock caused by having the event prompt backdrop activate during an active character event. Now the event system checks if the player is chatting before activating the backdrop just like how it does for minigames.