### PR TITLE
Maybe fix Go to Event bug

### DIFF
--- a/SpaceUber/Assets/Scripts/Event System/EventSystem.cs
+++ b/SpaceUber/Assets/Scripts/Event System/EventSystem.cs
@@ -135,6 +135,7 @@ public class EventSystem : MonoBehaviour
 	private IEnumerator Travel()
 	{
         progressBar = FindObjectOfType<ProgressBarUI>();
+        eventButtonSpawn = false;
         tick.DaysSince = 0; // reset days since
 		campMan.cateringToTheRich.SaveEventChoices();
 


### PR DESCRIPTION
This should fix the bug that has the Go to Event button pop up at the beginning of a job when it's not supposed to.