### PR TITLE
Crew glitch fixes

### DIFF
--- a/SpaceUber/Assets/Scripts/Event System/ChoiceOutcomes.cs
+++ b/SpaceUber/Assets/Scripts/Event System/ChoiceOutcomes.cs
@@ -140,24 +140,27 @@ public class ChoiceOutcomes
                                 resultText += "\nYou gained " + Math.Abs(newAmount) + " weapons";
                             }
                             break;
-                        case ResourceDataTypes._Crew: //TODO: Figure out how to scale crew
+                        case ResourceDataTypes._Crew: //losing crew
                             if (newAmount < 0)
                             {
                                 int amountFromAssigned;
                                 int amountFromUnassigned;
 
-                                //if total crew - unassigned crew is greater than newAmount to lose
+                                //if there are enough unassigned crew to lose, subtract from there
                                 if (ship.CrewCurrent.x - ship.CrewCurrent.z >= -newAmount)
                                 {
                                     amountFromAssigned = -newAmount;
                                     amountFromUnassigned = 0;
                                 }
-                                else
+                                else //if not, lose crew from assigned crew
                                 {
+                                    //crew current - unassigned
                                     amountFromAssigned = (int)ship.CrewCurrent.x - (int)ship.CrewCurrent.z;
                                     amountFromUnassigned = -newAmount - amountFromAssigned;
                                 }
+
                                 ship.RemoveRandomCrew(amountFromAssigned);
+
                                 ship.CrewCurrent += new Vector3(newAmount, 0, -amountFromUnassigned);
                                 SpawnStatChangeText(ship, newAmount, GameManager.instance.GetResourceData((int)ResourceDataTypes._Crew).resourceIcon);
                                 resultText += "\nYou lost " + Math.Abs(newAmount) + " crew";

--- a/SpaceUber/Assets/Scripts/Event System/ChoiceOutcomes.cs
+++ b/SpaceUber/Assets/Scripts/Event System/ChoiceOutcomes.cs
@@ -1,6 +1,6 @@
 /*
  * ChoiceOutcomes.cs
- * Author(s): Sam Ferstein
+ * Author(s): Sam Ferstein, Scott Acker
  * Created on: 9/18/2020 (en-US)
  * Description: Controls all outcomes of choices. When the player chooses to do something, code is directed here to determine the effects
  * Effects are written in the inspector
@@ -143,31 +143,31 @@ public class ChoiceOutcomes
                         case ResourceDataTypes._Crew: //losing crew
                             if (newAmount < 0)
                             {
-                                int amountFromAssigned;
-                                int amountFromUnassigned;
+                                //int amountFromAssigned;
+                                //int amountFromUnassigned;
 
-                                //if there are enough unassigned crew to lose, subtract from there
-                                if (ship.CrewCurrent.x - ship.CrewCurrent.z >= -newAmount)
-                                {
-                                    amountFromAssigned = -newAmount;
-                                    amountFromUnassigned = 0;
-                                }
-                                else //if not, lose crew from assigned crew
-                                {
-                                    //crew current - unassigned
-                                    amountFromAssigned = (int)ship.CrewCurrent.x - (int)ship.CrewCurrent.z;
-                                    amountFromUnassigned = -newAmount - amountFromAssigned;
-                                }
+                                ////if there are enough unassigned crew to lose, subtract from there
+                                //if (ship.CrewCurrent.x - ship.CrewCurrent.z >= -newAmount)
+                                //{
+                                //    amountFromAssigned = -newAmount;
+                                //    amountFromUnassigned = 0;
+                                //}
+                                //else //if not, lose crew from assigned crew
+                                //{
+                                //    //crew current - unassigned
+                                //    amountFromAssigned = (int)ship.CrewCurrent.x - (int)ship.CrewCurrent.z;
+                                //    amountFromUnassigned = -newAmount - amountFromAssigned;
+                                //}
 
-                                ship.RemoveRandomCrew(amountFromAssigned);
+                                //ship.RemoveRandomCrew(amountFromAssigned);
 
-                                ship.CrewCurrent += new Vector3(newAmount, 0, -amountFromUnassigned);
+                                ship.CrewCurrent += new Vector3(newAmount, 0, 0);
                                 SpawnStatChangeText(ship, newAmount, GameManager.instance.GetResourceData((int)ResourceDataTypes._Crew).resourceIcon);
                                 resultText += "\nYou lost " + Math.Abs(newAmount) + " crew";
                             }
                             else
                             {
-                                ship.CrewCurrent += new Vector3(newAmount, 0, newAmount);
+                                ship.CrewCurrent += new Vector3(newAmount, 0, 0);
                                 SpawnStatChangeText(ship, newAmount, GameManager.instance.GetResourceData((int)ResourceDataTypes._Crew).resourceIcon);
                                 resultText += "\nYou gained " + Math.Abs(newAmount) + " crew";
                             }

--- a/SpaceUber/Assets/Scripts/ShipStats.cs
+++ b/SpaceUber/Assets/Scripts/ShipStats.cs
@@ -346,8 +346,9 @@ public class ShipStats : MonoBehaviour
 
             shipStatsUI.UpdateCrewUI(stats[(int) Stats.CrewUnassigned], stats[(int) Stats.CrewCurrent], stats[(int) Stats.CrewCapacity]);
             shipStatsUI.ShowCrewUIChange((int)(value.z - prevValue.z), (int)(value.x - prevValue.x), (int)(value.y - prevValue.y));
-            
-            if(GameManager.instance.currentGameState == InGameStates.Events && value.x - prevValue.x > 0)
+            shipStatsUI.UpdateFoodUI(stats[(int)Stats.Food], stats[(int)Stats.FoodPerTick], stats[(int)Stats.CrewCurrent]);
+
+            if (GameManager.instance.currentGameState == InGameStates.Events && value.x - prevValue.x > 0)
             {
                 EndingStats.instance.AddToStat((int)(value.x - prevValue.x), EndingStatTypes.Crew);
             }


### PR DESCRIPTION
## Describe Changes
------
Deleted some unnecessary text in the choice outcomes related to crew. Basically, the crew changes do not double up and mess things up anymore

### Associated Jira Tasks
Fix Bug - Crew Missing from Usage, but not Calculations (Cause of Events?)

#### Tasks
T1C-883 Fix Bug - Crew Missing from Usage, but not Calculations (Cause of Events?)

### GitHub Issues Fixed _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues this solves:

#### Issues Fixed
None 

### Merge Checklist _(Learn more about [task lists](https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists))_
- [x] Update Branch with base (i.e. development/master)
- [x] Merge Conflicts Resolved (if you need help ask Steven - @NightAngel47 )
- [x] Have team members review changes in Unity (add to review pull request and @ them on Discord in pppp-pull-request-review channel)
- [x] Have reviewers add review to pull request (under Files Changed tab of pull request)
- [x] Have automated build system passes all checks
- [ ] Merge pull request
- [ ] Close any associated issues on GitHub (if any were listed above)
- [ ] Update any associated tasks in Jira
