### PR TITLE
Added Check before Delete for being in Ship Building in ObjectScript

### DIFF
--- a/SpaceUber/Assets/Scripts/ShipBuilding/ObjectScript.cs
+++ b/SpaceUber/Assets/Scripts/ShipBuilding/ObjectScript.cs
@@ -76,7 +76,12 @@ public class ObjectScript : MonoBehaviour
             StartCoroutine(WaitToClickRoom());
         }
 
-        if (Input.GetButtonDown("DeleteRoom") && FindObjectOfType<CrewManagementRoomDetailsMenu>().selectedRoom == gameObject && !preplacedRoom && ObjectMover.hasPlaced && !isDeleting)
+        if (Input.GetButtonDown("DeleteRoom") && 
+            GameManager.instance.currentGameState == InGameStates.ShipBuilding && 
+            FindObjectOfType<CrewManagementRoomDetailsMenu>().selectedRoom == gameObject && 
+            !preplacedRoom && 
+            ObjectMover.hasPlaced && 
+            !isDeleting)
         {
             StartCoroutine(Delete());
         }


### PR DESCRIPTION
## Describe Changes
------
Delete in ObjectScript didn't have the check for being in ship building, which was causing deleting placed room possible in runtime.

### Associated Jira Tasks
List of related Jira tasks this involves:

#### Tasks
None

### GitHub Issues Fixed _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues this solves:

#### Issues Fixed
Could delete placed rooms outside of ship building.

### Merge Checklist _(Learn more about [task lists](https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists))_
- [x] Update Branch with base (i.e. development/master)
- [x] Merge Conflicts Resolved (if you need help ask Steven - @NightAngel47 )
- [x] Have team members review changes in Unity (add to review pull request and @ them on Discord in pppp-pull-request-review channel)
- [ ] Have reviewers add review to pull request (under Files Changed tab of pull request)
- [ ] Have automated build system passes all checks
- [ ] Merge pull request
- [ ] Close any associated issues on GitHub (if any were listed above)
- [ ] Update any associated tasks in Jira
