### PR TITLE
Begin Job Button Fixed

### DIFF
--- a/SpaceUber/Assets/Scripts/CrewManagement.cs
+++ b/SpaceUber/Assets/Scripts/CrewManagement.cs
@@ -42,6 +42,7 @@ public class CrewManagement : MonoBehaviour
     public IEnumerator CheckForRooms()
     {
         yield return new WaitUntil(() => FindObjectOfType<SpotChecker>());
+        yield return new WaitUntil(() => GameManager.instance.hasLoadedRooms);
         passedRoomCount = FindObjectsOfType<RoomStats>().Length > minRoomPlacedToContinue;
 
         CheckForMinCrew();


### PR DESCRIPTION
## Describe Changes
------
The begin job button now correctly updates when reloading the game to be enabled if you have enough rooms and enough crew in rooms to begin a job.  

### Associated Jira Tasks
List of related Jira tasks this involves:

#### Tasks
None

### GitHub Issues Fixed _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues this solves:

#### Issues Fixed
None

### Merge Checklist _(Learn more about [task lists](https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists))_
- [x] Update Branch with base (i.e. development/master)
- [x] Merge Conflicts Resolved (if you need help ask Steven - @NightAngel47 )
- [x] Have team members review changes in Unity (add to review pull request and @ them on Discord in pppp-pull-request-review channel)
- [ ] Have reviewers add review to pull request (under Files Changed tab of pull request)
- [ ] Have automated build system passes all checks
- [ ] Merge pull request
- [ ] Close any associated issues on GitHub (if any were listed above)
- [ ] Update any associated tasks in Jira
