### PR TITLE
Ending Game Deletes Save

### DIFF
--- a/SpaceUber/Assets/Scripts/EndingRestartBehaviour.cs
+++ b/SpaceUber/Assets/Scripts/EndingRestartBehaviour.cs
@@ -48,6 +48,8 @@ public class EndingRestartBehaviour : MonoBehaviour
     
     public void GoToMainMenu()
     {
+        SavingLoadingManager.instance.SetHasSaveFalse();
+        if(FindObjectOfType<SpotChecker>()) Destroy(FindObjectOfType<SpotChecker>().gameObject);
         SceneManager.LoadScene("Menu_Main");
     }
     


### PR DESCRIPTION
## Describe Changes
------
When you beat the game, you no longer can continue from your last job, cause your save now gets deleted.  

### Associated Jira Tasks
List of related Jira tasks this involves:

#### Tasks
T1C-922 - Fix Bug - After Ending the Game, Continuing is Available on Main Menu

### GitHub Issues Fixed _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues this solves:

#### Issues Fixed
Closes #537 - After Ending the Game, Continuing is Available on Main Menu

### Merge Checklist _(Learn more about [task lists](https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists))_
- [x] Update Branch with base (i.e. development/master)
- [x] Merge Conflicts Resolved (if you need help ask Steven - @NightAngel47 )
- [x] Have team members review changes in Unity (add to review pull request and @ them on Discord in pppp-pull-request-review channel)
- [ ] Have reviewers add review to pull request (under Files Changed tab of pull request)
- [ ] Have automated build system passes all checks
- [ ] Merge pull request
- [ ] Close any associated issues on GitHub (if any were listed above)
- [ ] Update any associated tasks in Jira
