### PR TITLE
station dial matches up with dots on sprite

### DIFF
--- a/SpaceUber/Assets/Scenes/Rendering.meta
+++ b/SpaceUber/Assets/Scenes/Rendering.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 9edcaf650c7eea043b24be71a936d683
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/SpaceUber/Assets/Scripts/Radio/RadioDial.cs
+++ b/SpaceUber/Assets/Scripts/Radio/RadioDial.cs
@@ -67,6 +67,7 @@ public class RadioDial : MonoBehaviour, IPointerEnterHandler, IPointerExitHandle
         SendAudioSettingsValues();
         if (dial == DialType.Station) SaveRadioSettings();
     }
+    
 
     void Update()
     {
@@ -101,7 +102,18 @@ public class RadioDial : MonoBehaviour, IPointerEnterHandler, IPointerExitHandle
             }*/
 
             //set slider values based on rotation
-            if (dial == DialType.Station) value = (Mathf.Abs(rotator.rotation.z) / 360f) * 100f * 20f;
+            //if (dial == DialType.Station) value = (Mathf.Abs(rotator.rotation.z) / 360f) * 100f * 20f;
+            if (dial == DialType.Station)
+            {
+                //within 4 degrees of each notch (20, 45, 90, 270, 315, 340 degrees) switch stations. 
+                if (rotator.rotation.eulerAngles.z > 18 && rotator.rotation.eulerAngles.z <= 22) value = 0;
+                else if (rotator.rotation.eulerAngles.z > 43 && rotator.rotation.eulerAngles.z <= 55) value = 1;
+                else if (rotator.rotation.eulerAngles.z > 88 && rotator.rotation.eulerAngles.z <= 92) value = 2;
+                else if (rotator.rotation.eulerAngles.z > 268 && rotator.rotation.eulerAngles.z <= 272) value = 3;
+                else if (rotator.rotation.eulerAngles.z > 305 && rotator.rotation.eulerAngles.z <= 317) value = 4;
+                else if (rotator.rotation.eulerAngles.z > 338 && rotator.rotation.eulerAngles.z <= 342) value = 5;
+
+            }
             else value = 1 - (rotator.rotation.eulerAngles.z / 360);
 
             UpdateRadioManager();


### PR DESCRIPTION
station dial matches up with dots on sprite

### Associated Jira Tasks
T1C-925 Fix Bug - Radio Stations Not Set to Dial Dots

#### Issues Fixed
Radio Stations Not Set to Dial Dots #566

### Merge Checklist _(Learn more about [task lists](https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists))_
- [x] Update Branch with base (i.e. development/master)
- [x] Merge Conflicts Resolved (if you need help ask Steven - @NightAngel47 )
- [ ] Have team members review changes in Unity (add to review pull request and @ them on Discord in pppp-pull-request-review channel)
- [ ] Have reviewers add review to pull request (under Files Changed tab of pull request)
- [ ] Have automated build system passes all checks
- [ ] Merge pull request
- [ ] Close any associated issues on GitHub (if any were listed above)
- [ ] Update any associated tasks in Jira
