### PR TITLE
Game now skips ending stats screen

### DIFF
--- a/SpaceUber/Assets/Scenes/Prompt Screens/PromptScreen_Morale_End.unity
+++ b/SpaceUber/Assets/Scenes/Prompt Screens/PromptScreen_Morale_End.unity
@@ -163,7 +163,7 @@ MonoBehaviour:
     be certain death.  You are just as cold hearted and artificial as the CEO's who
     built you.  I feel sorry for whoever is unfortunate enough to end up on your
     crew in the future.  \n\t\t\t\t\t\tSincerely,\n\t\t\t\t\t\tCaptain Lexa"
-  stateToTransition: 11
+  stateToTransition: 12
   characterSignatures:
   - character: 0
     threshold: 3

--- a/SpaceUber/Assets/Scenes/Prompt Screens/PromptScreen_Morale_End.unity
+++ b/SpaceUber/Assets/Scenes/Prompt Screens/PromptScreen_Morale_End.unity
@@ -158,7 +158,8 @@ MonoBehaviour:
   meetsThresholdText: "Dear Ship AI,\n\tThank you for being such a great captain. 
     Everyone appreciates your generosity and genuine care for our lives, despite
     the hardships we've faced.  We've all pitched in to get you a gift and can't
-    wait to see you enjoy it during future jobs.  \n\t\t\t\t\t\tSincerely,\n"
+    wait to see you enjoy it during future jobs.  \n\t\t\t\t\t\tSincerely,\n\t\t\t\t\t\tYour
+    Crew\n"
   belowThresholdText: "Ship AI,\n\tEveryone has agreed that staying any longer would
     be certain death.  You are just as cold hearted and artificial as the CEO's who
     built you.  I feel sorry for whoever is unfortunate enough to end up on your

--- a/SpaceUber/Assets/Scripts/GameManager.cs
+++ b/SpaceUber/Assets/Scripts/GameManager.cs
@@ -244,14 +244,10 @@ public class GameManager : MonoBehaviour
 
                 additiveSceneManager.LoadSceneSeperate("PromptScreen_Morale_End");
                 break;
-            case InGameStates.EndingStats: // Loads the Interface_EndScreen_Stats after the PromptScreen_Morale_End.
+            case InGameStates.EndingStats: // Keeping only to not have errors, load into ending credits instead
+            case InGameStates.EndingCredits: // Loads the Credits after the Interface_EndScreen_Stats.
                 additiveSceneManager.UnloadScene("Event_NoChoices");
                 additiveSceneManager.UnloadScene("PromptScreen_Morale_End");
-                
-                additiveSceneManager.LoadSceneSeperate("Interface_EndScreen_Stats");
-                break;
-            case InGameStates.EndingCredits: // Loads the Credits after the Interface_EndScreen_Stats.
-                additiveSceneManager.UnloadScene("Interface_EndScreen_Stats");
                 
                 additiveSceneManager.LoadSceneSeperate("Credits");
                 break;

--- a/SpaceUber/ProjectSettings/EditorBuildSettings.asset
+++ b/SpaceUber/ProjectSettings/EditorBuildSettings.asset
@@ -57,17 +57,11 @@ EditorBuildSettings:
     path: Assets/Scenes/Interfaces/Interface_GameOver.unity
     guid: b289b7b603e76574e94096db3758ce08
   - enabled: 1
-    path: Assets/Scenes/Interfaces/Interface_EndScreen_Stats.unity
-    guid: 057bb296c821d2349bda6ffb2912dbc8
-  - enabled: 1
     path: Assets/Scenes/Prompt Screens/PromptScreen_Money_End.unity
     guid: 1e4d1e9e8e54ce04faf90e9ca347699c
   - enabled: 1
     path: Assets/Scenes/Prompt Screens/PromptScreen_Morale_End.unity
     guid: d996022bc124443e2af3beaaa599e8d5
-  - enabled: 1
-    path: Assets/Scenes/Events/Event_Prompt.unity
-    guid: d6a4c22821553c846859b9eca91f56fa
   - enabled: 1
     path: Assets/Scenes/Events/Event_NoChoices.unity
     guid: 791033168f946704d924970ee65a99ca
@@ -77,9 +71,6 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Events/Event_CharacterFocused.unity
     guid: a264bb79a1715924fb4b071bb0db48b4
-  - enabled: 1
-    path: Assets/Scenes/MiniGames/MiniGames Testing Menu.unity
-    guid: c5d9bf7f42e0d0a4eb0c8003f38d6c36
   - enabled: 1
     path: Assets/Scenes/MiniGames/CropHarvest.unity
     guid: bfaf6f4035a456942b01f16b4e153d51
@@ -98,6 +89,9 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/MiniGames/HullRepair.unity
     guid: 82f26039cb89e164fb2693e7a48cc754
+  - enabled: 1
+    path: Assets/Scenes/MiniGames/MiniGames Testing Menu.unity
+    guid: c5d9bf7f42e0d0a4eb0c8003f38d6c36
   - enabled: 1
     path: Assets/Scenes/Credits.unity
     guid: 1ccd4c5622a884e16b44ad24b07cd5e0


### PR DESCRIPTION
## Describe Changes
------
It now transitions directly from the morale ending to the credits instead of going to the end stats screen first.  

### Associated Jira Tasks
List of related Jira tasks this involves:

#### Tasks
None

### GitHub Issues Fixed _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues this solves:

#### Issues Fixed
None

### Merge Checklist _(Learn more about [task lists](https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists))_
- [x] Update Branch with base (i.e. development/master)
- [x] Merge Conflicts Resolved (if you need help ask Steven - @NightAngel47 )
- [x] Have team members review changes in Unity (add to review pull request and @ them on Discord in pppp-pull-request-review channel)
- [x] Have reviewers add review to pull request (under Files Changed tab of pull request)
- [ ] Have automated build system passes all checks
- [ ] Merge pull request
- [x] Close any associated issues on GitHub (if any were listed above)
- [x] Update any associated tasks in Jira
