### PR TITLE
Game Over Main Menu Fix

### DIFF
--- a/SpaceUber/Assets/Scenes/Interfaces/Interface_GameOver.unity
+++ b/SpaceUber/Assets/Scenes/Interfaces/Interface_GameOver.unity
@@ -286,7 +286,7 @@ PrefabInstance:
     - target: {fileID: 8963481259364165007, guid: 7c6b2fb6150cea44b9c7fcd233a2c0a5,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: GoToMainMenu
+      value: ResetJobAndQuitToMainMenu
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7c6b2fb6150cea44b9c7fcd233a2c0a5, type: 3}

--- a/SpaceUber/Assets/Scripts/EndingRestartBehaviour.cs
+++ b/SpaceUber/Assets/Scripts/EndingRestartBehaviour.cs
@@ -46,6 +46,13 @@ public class EndingRestartBehaviour : MonoBehaviour
         AudioManager.instance.PlayMusicWithTransition("General Theme");
     }
     
+    public void ResetJobAndQuitToMainMenu()
+    {
+        if(FindObjectOfType<SpotChecker>()) Destroy(FindObjectOfType<SpotChecker>().gameObject);
+        GameManager.instance.ChangeInGameState(InGameStates.ShipBuilding);
+        SceneManager.LoadScene("Menu_Main");
+    }
+    
     public void GoToMainMenu()
     {
         SavingLoadingManager.instance.SetHasSaveFalse();


### PR DESCRIPTION
## Describe Changes
------
Now exiting to main menu on the game over screen only resets the job instead of deleting your whole save.  

### Associated Jira Tasks
List of related Jira tasks this involves:

#### Tasks
None

### GitHub Issues Fixed _(Make sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords))_
List of related issues this solves:

#### Issues Fixed
None

### Merge Checklist _(Learn more about [task lists](https://docs.github.com/en/github/managing-your-work-on-github/about-task-lists))_
- [x] Update Branch with base (i.e. development/master)
- [x] Merge Conflicts Resolved (if you need help ask Steven - @NightAngel47 )
- [x] Have team members review changes in Unity (add to review pull request and @ them on Discord in pppp-pull-request-review channel)
- [x] Have reviewers add review to pull request (under Files Changed tab of pull request)
- [ ] Have automated build system passes all checks
- [ ] Merge pull request
- [x] Close any associated issues on GitHub (if any were listed above)
- [x] Update any associated tasks in Jira
